### PR TITLE
Add evident indexes to rating and cache tables

### DIFF
--- a/db/data/db_schema.sql
+++ b/db/data/db_schema.sql
@@ -13,6 +13,11 @@ CREATE TABLE IF NOT EXISTS `cache` (
   `exp` int(11) NOT NULL,
   `delta` int(11) NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+CREATE INDEX `cache_course` ON `cache` (`course`);
+CREATE INDEX `cache_user` ON `cache` (`user`);
+CREATE INDEX `cache_exp` ON `cache` (`exp`);
+CREATE INDEX `cache_delta` ON `cache` (`delta`);
+CREATE INDEX `cache_course_user` ON `cache` (`course`, `user`);
 
 CREATE TABLE IF NOT EXISTS `rating` (
   `course` int(11) NOT NULL,
@@ -21,6 +26,11 @@ CREATE TABLE IF NOT EXISTS `rating` (
   `id` int(11) NOT NULL PRIMARY KEY AUTO_INCREMENT,
   `updated_at` datetime NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+CREATE INDEX `rating_course` ON `rating` (`course`);
+CREATE INDEX `rating_user` ON `rating` (`user`);
+CREATE INDEX `rating_exp` ON `rating` (`exp`);
+CREATE INDEX `rating_updated_at` ON `rating` (`updated_at`);
+CREATE INDEX `rating_course_user` ON `rating` (`course`, `user`);
 
 CREATE TABLE IF NOT EXISTS `users` (
   `id` int(11) NOT NULL PRIMARY KEY


### PR DESCRIPTION
UNIQUE индекс на пару (`course`, `user`) создать не получается, т.к. есть записи с одинаковыми значениями этой пары.
После добавления индексов нагрузка на CPU значительно уменьшилась, график Load average:
<img width="335" alt="screen shot 2018-05-25 at 20 43 18" src="https://user-images.githubusercontent.com/783910/40558555-54a5ec72-605c-11e8-8c82-d5c10c8cb75a.png">
